### PR TITLE
Add global SUPPORT.md tab

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# WireMock Support
+
+WireMock is an open source project.
+In accordance with the [Apache License 2.0](https://github.com/wiremock/wiremock/blob/master/LICENSE.txt),
+in general there is no support or guarantees provided for it.
+At the same time, you can get some assistance through WireMock community channels,
+and contribute to helping other users too.
+There are also vendors that provide commercial support for WireMock.
+
+## WireMock Community
+
+If you’re looking for help or advice,
+you can find a community of users and contributors on the WireMock community Slack or mailing list.
+Stack Overflow also has many good WireMock questions and answers.
+
+Note that all the community channels are maintained without a Service Level Agreement (SLA).
+All responses are provided by community members, and it is a best effort.
+Every community member is welcome 
+
+- [WireMock Slack](https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A),
+in particular the `#setup` and `#general` channels.
+- [User Mailing List](https://groups.google.com/forum/#!forum/wiremock-user)
+- [WireMock tag on StackOverflow](https://stackoverflow.com/questions/tagged/wiremock)
+
+## Commercial support and consulting
+
+### Priority Support by WireMock Inc
+
+WireMock Inc offers priority support with a guaranteed SLA as part the [WireMock Cloud](https://www.wiremock.io/) Enterprise plan.
+You can find more info about WireMock Cloud support plans [here](https://www.wiremock.io/pricing).
+
+[Get in touch with our team](https://share-eu1.hsforms.com/1YSKnSP93Tsig1JoO3lXSawfbdiq) to discuss options or get a demo.
+
+### Other commercial options
+
+Other commercial options are not documented at the moment.
+Any company or individual consultant are welcome to submit a pull request and to extend information on this page.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ There are also vendors that provide commercial support for WireMock.
 ## WireMock Community
 
 If you’re looking for help or advice,
-you can find a community of users and contributors on the WireMock community Slack or mailing list.
+you can find a community of users and contributors on the WireMock community Slack channels.
 Stack Overflow also has many good WireMock questions and answers.
 
 Note that all the community channels are maintained without a Service Level Agreement (SLA).
@@ -19,7 +19,6 @@ Every community member is welcome
 
 - [WireMock Slack](https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A),
 in particular the `#setup` and `#general` channels.
-- [User Mailing List](https://groups.google.com/forum/#!forum/wiremock-user)
 - [WireMock tag on StackOverflow](https://stackoverflow.com/questions/tagged/wiremock)
 
 ## Commercial support and consulting


### PR DESCRIPTION
Initializes the SUPPORT metadata for all GitHub repositories, unless overridden. Once added, users will be advised to join the community channels. There is also a reference to WireMock Cloud and its enterprise plans, similar to https://wiremock.org/support/