### PR TITLE
doc: remove Hacktoberfest reference

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -15,15 +15,6 @@ spreading the word about WireMock and submitting proposals and issue reports.
 Here's our [Contributor Guide](https://github.com/wiremock/community/tree/main/contributing) where we 
 Join the community on [Slack](https://slack.wiremock.org) and the `#help-contributing` channel to get started.
 
-
-### Join us for Hacktoberfest 2023!
-
-This October we participate in Hacktoberfest - a global open source hack fest. We invite you to join us, regardless of your profile and technology stack.
-Adopt WireMock in your projects, contribute new features and fixes, improve docs, create new demos and artwork, etc.
-[Learn More...](https://wiremock.org/events/hacktoberfest/)
-
-[![WireMock in Hacktoberfest 2023](https://raw.githubusercontent.com/wiremock/community/main/events/hacktoberfest/2013/wiremock_hacktoberfest_header.png)](https://wiremock.org/events/hacktoberfest/)
-
 Also follow us on [Twitter](https://twitter.com/wiremockorg),
 [LinkedIn](https://www.linkedin.com/company/wiremock/),
 [Mastodon](https://fosstodon.org/@wiremock)


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- Removes the Hacktoberfest reference given the end of the event.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
